### PR TITLE
Update fish_and_chips.json

### DIFF
--- a/src/main/resources/data/cooksrecipes/recipe/fish_and_chips.json
+++ b/src/main/resources/data/cooksrecipes/recipe/fish_and_chips.json
@@ -5,7 +5,7 @@
       "item": "cookscollection:fried_potato"
     },
     {
-      "tag": "c:foods/cooked_fishes"
+      "tag": "c:foods/cooked_fish"
     },
     {
       "item": "minecraft:bowl"
@@ -20,3 +20,4 @@
   }
 
 }
+

--- a/src/main/resources/data/cooksrecipes/recipe/fish_and_chips.json
+++ b/src/main/resources/data/cooksrecipes/recipe/fish_and_chips.json
@@ -5,7 +5,7 @@
       "item": "cookscollection:fried_potato"
     },
     {
-      "tag": "c:cooked_fishes"
+      "tag": "c:foods/cooked_fishes"
     },
     {
       "item": "minecraft:bowl"
@@ -18,4 +18,5 @@
     "count": 1,
     "id": "cookscollection:fish_and_chips"
   }
+
 }


### PR DESCRIPTION
Fix recipe fish_and_chips v1 (e35b28db3e9afb8fd9a1c20d60ed5c54ad8c764f) = minecraft cod, salmon
Fix recipe fish_and_chips v2 (0f487ba87e44e14dad9f7a15e5ae69fda6967b94) = probably most modded cooked fishes too, like Farmer's Delight cooked slices or The Undergarden's Gwibling


++ both the latest .jars (`cookscollection-0.5.4.jar`) in Modrinth and CurseForge have two more errors in recipes that you have already fixed but maybe didn't compile the correct version of the mod. The iron ingot for the oven and the 3 rabbit.